### PR TITLE
fix: update default dash character

### DIFF
--- a/pkg/tailer/options.go
+++ b/pkg/tailer/options.go
@@ -7,7 +7,7 @@ import (
 )
 
 const DefaultWaitDuration = 1 * time.Second
-const DefaultDashString = "━"
+const DefaultDashString = "─"
 
 type options struct {
 	inrd          io.Reader


### PR DESCRIPTION
This character (U+2500 - Box Drawings Light Horizontal) is better suited for drawing lines since most fonts will render several of these as one continuous line with no overlap.

The previous character caused a weird overlap on some fonts.

Before:

![Screenshot 2023-06-30 at 10 32 58](https://github.com/hionay/tailer/assets/3630554/5da854f3-5fa8-4e3b-89f1-1297a89c139d)

After:

![Screenshot 2023-06-30 at 10 33 34](https://github.com/hionay/tailer/assets/3630554/85b71372-c23f-4e24-b01f-f8cc66fba6c9)
